### PR TITLE
Fix dialog box on back button press

### DIFF
--- a/UI/admin/users.html
+++ b/UI/admin/users.html
@@ -30,7 +30,7 @@
         <div id="popup1" class="overlay">
             <div class="popup">
                 <h2 id="mb_title">Message</h2>
-                <a id="mb_link" class="close" href="#">&times;</a>
+                <a id="mb_link" onclick="history.back(-2)" class="close" href="#">&times;</a>
                 <div id="mb_msg" class="content">
                     Client verification successful.
                 </div>


### PR DESCRIPTION
Currently, when you verify a client and get a feedback dialog, if you
hit back button to navigate away from the page, you will have the
dialog popup again.

If this commit is accepted it will fix the dialog back on back button
press bug