### PR TITLE
Fix bug invalid id crash app in createRepayment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,8 @@ module.exports = {
     },
     "extends": "airbnb-base",
     "rules": {
-        "no-console": "off"
-    }
+        "no-console": "off",
+        "import/no-extraneous-dependencies": true
+    },
+    
 };

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ dotenv.config();
 
 // declare constants
 const app = new Express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT;
 
 // declare middleware
 app.use(bodyParser.urlencoded({

--- a/server/controllers/loansController.js
+++ b/server/controllers/loansController.js
@@ -118,7 +118,7 @@ class LoansController {
     const userId = Number.parseInt(req.params.loanId, 10);
 
     const loan = loansModel.getSingleLoan(userId);
-    if (loan === undefined) {
+    if (loan === 'no-loan') {
       return ResponseHelper.error(res, 404, errorStrings.noLoan);
     }
     return ResponseHelper.success(res, 200, loan);

--- a/server/controllers/repaymentsController.js
+++ b/server/controllers/repaymentsController.js
@@ -22,7 +22,7 @@ class RepaymentsController {
 
   static getLoanRepayments(req, res) {
     const loanId = parseInt(req.params.loanId, 10);
-    const loanRepayments = RepaymentsController.getLoanRepayments(loanId);
+    const loanRepayments = RepaymentsModel.getLoanRepayments(loanId);
     if (Utils.checkLength(loanRepayments) > 0) {
       return ResponseHelper.success(res, 200, loanRepayments);
     }

--- a/server/controllers/repaymentsController.js
+++ b/server/controllers/repaymentsController.js
@@ -22,7 +22,7 @@ class RepaymentsController {
 
   static getLoanRepayments(req, res) {
     const loanId = parseInt(req.params.loanId, 10);
-    const loanRepayments = RepaymentsModel.getLoanRepayments(loanId);
+    const loanRepayments = RepaymentsController.getLoanRepayments(loanId);
     if (Utils.checkLength(loanRepayments) > 0) {
       return ResponseHelper.success(res, 200, loanRepayments);
     }
@@ -40,6 +40,9 @@ class RepaymentsController {
     const loanId = parseInt(req.params.loanId, 10);
     const { amount } = req.body;
     const newRepayment = RepaymentsModel.createRepayment(loanId, amount);
+    if (newRepayment === 'no-loan') {
+      return ResponseHelper.error(res, 404, errorStrings.noLoan);
+    }
     if (newRepayment === 'not-approved') {
       return ResponseHelper.error(res, 406, errorStrings.notApproved);
     }

--- a/server/model/loansModel.js
+++ b/server/model/loansModel.js
@@ -62,7 +62,11 @@ class LoansModel {
      */
 
   static getSingleLoan(loanId) {
-    return Utils.findSingleItem(loanId, 'id', loans);
+    const loan = Utils.findSingleItem(loanId, 'id', loans);
+    if (loan === undefined) {
+      return 'no-loan';
+    }
+    return loan;
   }
 
   /**

--- a/server/model/repaymentsModel.js
+++ b/server/model/repaymentsModel.js
@@ -68,6 +68,9 @@ class RepaymentsModel {
 
   static checkCreateRepayment(loan, amount) {
     const result = '';
+    if (loan === 'no-loan') {
+      return 'no-loan';
+    }
     if (loan.status !== 'approved') {
       return 'not-approved';
     }

--- a/server/tests/repaymentsTest.js
+++ b/server/tests/repaymentsTest.js
@@ -159,6 +159,20 @@ describe('Repayment Controller', () => {
         });
     });
 
+    it('it should return error loan id does not exist', (done) => {
+      chai.request(app)
+        .post(`${loansUrl}/99/repayment`)
+        .send(testDb.repaymentAmount[3])
+        .set('token', currentToken)
+        .end((error, res) => {
+          res.should.have.status(404);
+          res.body.should.be.a('object');
+          res.body.should.have.property('error');
+          res.body.error.should.equal(errorStrings.noLoan);
+          done();
+        });
+    });
+
     it('it should return error if loan is not approved', (done) => {
       chai.request(app)
         .post(`${loansUrl}/3/repayment`)


### PR DESCRIPTION
Whenever a user tries to repay a loan with a loanId that doesn't exist in the
data model, the app crashes instead of displaying corresponding error.