### PR TITLE
FIX: different migration script for test to increase coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint ./server",
-    "migration": "DEBUG=app/debug node ./dist/model/db/migrations.db",
-    "seeder": "node ./dist/model/db/seeders.db",
-    "exec-db-dev": "npm run build && npm run migration && npm run seeder",
+    "migration": "node ./dist/model/db/migrations.db",
+    "dev-migration": "DEBUG=app/debug babel-node ./server/model/db/migrations.db",
+    "seeder": "babel-node ./server/model/db/seeders.db",
+    "exec-db-dev": "npm run dev-migration && npm run seeder",
     "exec-db-production": "npm run build",
     "start-dev": "NODE_ENV=development npm run exec-db-dev && NODE_ENV=development DEBUG=app/debug nodemon --exec babel-node ./server/app.js",
     "build": "babel ./server --out-dir ./dist --copy-files --ignore ./node_modules,./coverage,./.babelrc,.nyc_output,./package.json,./npm-debug.log,./.travis.yml,./.eslintrc.js,./UI,./README.md",

--- a/server/app.js
+++ b/server/app.js
@@ -37,12 +37,12 @@ app.use(cors('*'));
 
 routes(app);
 
-app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
+app.get('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
 
 // At the moment GET request on '/' should show documentation
-app.use('/api/v1', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
+app.get('/', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
 
-// declare 404 route
+// invalid url
 app.all('*', (req, res) => ResponseHelper.error(res, 404, errorStrings.pageNotFound));
 
 // listen to app port

--- a/server/tests/index.js
+++ b/server/tests/index.js
@@ -9,7 +9,7 @@ chai.should();
 describe('Home page', () => {
   it('it should take users to the landing page', (done) => {
     chai.request(app)
-      .get('/api/v1/')
+      .get('/')
       .end((error, res) => {
         res.should.have.status(200);
         res.body.should.be.a('object');


### PR DESCRIPTION
Usually, migration script use babel compiled files from ./dist folder, this makes test coverage drop.